### PR TITLE
feat: Complication ModularLarge

### DIFF
--- a/Time for Coffee! WatchOS 2 App Extension/Assets.xcassets/Contents.json
+++ b/Time for Coffee! WatchOS 2 App Extension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Time for Coffee! WatchOS 2 App Extension/ComplicationController.swift
+++ b/Time for Coffee! WatchOS 2 App Extension/ComplicationController.swift
@@ -1,0 +1,225 @@
+//
+//  ComplicationController.swift
+//  timeforcoffee
+//
+//  Created by Raphael Neuenschwander on 11.10.15.
+//  Copyright © 2015 opendata.ch. All rights reserved.
+//
+
+// create the timeline entries (departures) to populate the complication
+
+import ClockKit
+
+//MARK: - Constants
+
+private struct Constants {
+    static let DepartureDuration = NSTimeInterval(60) // 1 minute
+    static let FrequencyOfTimelineUpdate = NSTimeInterval(1.5*60*60) // 1.5 hour
+}
+
+class ComplicationController: NSObject, CLKComplicationDataSource {
+    
+    // MARK: - Timeline Configuration
+    
+    func getSupportedTimeTravelDirectionsForComplication(complication: CLKComplication, withHandler handler: (CLKComplicationTimeTravelDirections) -> Void) {
+        handler([.Forward]) // supports only forward time travel
+    }
+    
+    func getTimelineStartDateForComplication(complication: CLKComplication, withHandler handler: (NSDate?) -> Void) {
+        func handleReply(stations: TFCStations?) {
+            if let station = stations?.stations?.first {
+                if let departure = station.getFilteredDepartures()?.first {
+                    let startDate = timelineEntryDateForDeparture(departure, previousDeparture: nil)
+                    handler(startDate)
+                }
+            }
+        }
+        TFCWatchData.sharedInstance.getStations(handleReply, errorReply: nil, stopWithFavorites: true)
+    }
+    
+    func getTimelineEndDateForComplication(complication: CLKComplication, withHandler handler: (NSDate?) -> Void) {
+        func handleReply(stations: TFCStations?) {
+            if let station = stations?.stations?.first {
+                let endDate = station.getFilteredDepartures()?.last?.getScheduledTimeAsNSDate()
+                handler(endDate)
+            }
+        }
+        TFCWatchData.sharedInstance.getStations(handleReply, errorReply: nil, stopWithFavorites: true)
+    }
+    
+    func getPrivacyBehaviorForComplication(complication: CLKComplication, withHandler handler: (CLKComplicationPrivacyBehavior) -> Void) {
+        handler(.ShowOnLockScreen)
+    }
+    
+    // MARK: - Timeline Population
+    
+    func getCurrentTimelineEntryForComplication(complication: CLKComplication, withHandler handler: ((CLKComplicationTimelineEntry?) -> Void)) {
+        // Take the first entry before the current date
+        getTimelineEntriesForComplication(complication, beforeDate: NSDate(), limit: 1) { (entries) -> Void in
+            handler(entries?.first)
+        }
+    }
+    
+    func getTimelineEntriesForComplication(complication: CLKComplication, beforeDate date: NSDate, limit: Int, withHandler handler: (([CLKComplicationTimelineEntry]?) -> Void)) {
+        // Call the handler with the timeline entries after to the given date
+        
+        func handleReply(stations: TFCStations?) {
+            var entries = [CLKComplicationTimelineEntry]()
+            
+            if let station = stations?.stations?.first { // corresponds to the last favorited station or closest station
+                if let departures = station.getFilteredDepartures() {
+                    var index = departures.count - 1
+                    var nextDeparture: TFCDeparture? = nil
+                    var departure: TFCDeparture? = departures.last
+                    var previousDeparture: TFCDeparture? = (departures.count >= 2 ) ? departures[index - 1] : nil
+                    
+                    while let thisDeparture = departure {
+                        let thisEntryDate = timelineEntryDateForDeparture(thisDeparture, previousDeparture: previousDeparture)
+                        if date.compare(thisEntryDate) == .OrderedDescending { // check if the entry date is "correctly" before the given date
+                            let tmpl = templateForStationDepartures(station, departure: thisDeparture, nextDeparture: nextDeparture, complication: complication)
+                            let entry = CLKComplicationTimelineEntry(date: thisEntryDate, complicationTemplate: tmpl)
+                            entries.append(entry)
+                            if entries.count == limit {break} // break if we reached the limit of entries
+                        }
+                        index--
+                        nextDeparture = departure
+                        departure = previousDeparture
+                        previousDeparture = (index > 0 ) ? departures[index - 1] : nil
+                    }
+                    handler(entries)
+                }
+            }
+        }
+        
+        TFCWatchData.sharedInstance.getStations(handleReply, errorReply: nil, stopWithFavorites: true)
+    }
+    
+    func getTimelineEntriesForComplication(complication: CLKComplication, afterDate date: NSDate, limit: Int, withHandler handler: (([CLKComplicationTimelineEntry]?) -> Void)) {
+        // Call the handler with the timeline entries after to the given date
+        
+        func handleReply(stations: TFCStations?) {
+            var entries = [CLKComplicationTimelineEntry]()
+            
+            if let station = stations?.stations?.first { // corresponds to the favorited/closest station
+                if let departures = station.getFilteredDepartures() {
+                    
+                    var index = 0
+                    var previousDeparture: TFCDeparture? = nil
+                    var departure: TFCDeparture? = departures.first
+                    var nextDeparture: TFCDeparture? = (departures.count >= 2) ? departures[1] : nil
+                    
+                    while let thisDeparture = departure {
+                        let thisEntryDate = timelineEntryDateForDeparture(thisDeparture, previousDeparture: previousDeparture)
+                        if date.compare(thisEntryDate) == .OrderedAscending { // check if the entry date is "correctly" after the given date
+                            let tmpl = templateForStationDepartures(station, departure: thisDeparture, nextDeparture: nextDeparture, complication: complication)
+                            let entry = CLKComplicationTimelineEntry(date: thisEntryDate, complicationTemplate: tmpl)
+                            entries.append(entry)
+                            if entries.count == limit {break} // break if we reached the limit of entries
+                        }
+                        index++
+                        previousDeparture = thisDeparture
+                        departure = (departures.count - 1 >= index) ? departures[index] : nil
+                        nextDeparture = (departures.count > index + 1) ? departures[index + 1] : nil
+                    }
+                    
+                handler(entries)
+                }
+            }
+        }
+        TFCWatchData.sharedInstance.getStations(handleReply, errorReply: nil, stopWithFavorites: true)
+    }
+    
+    // MARK: - Update Scheduling
+    
+    func getNextRequestedUpdateDateWithHandler(handler: (NSDate?) -> Void) {
+        // Call the handler with the date when you would next like to be given the opportunity to update your complication content
+        let nextUpdateDate = NSDate().dateByAddingTimeInterval(Constants.FrequencyOfTimelineUpdate) // request an update each 1.5 hour
+        handler(nextUpdateDate);
+    }
+    
+    // MARK: - Placeholder Templates
+    
+    func getPlaceholderTemplateForComplication(complication: CLKComplication, withHandler handler: (CLKComplicationTemplate?) -> Void) {
+        
+        switch complication.family {
+            
+        case CLKComplicationFamily.ModularLarge:
+            let tmpl = CLKComplicationTemplateModularLargeTable()
+            
+            tmpl.headerTextProvider = CLKSimpleTextProvider(text: "Station")
+            tmpl.row1Column1TextProvider = CLKSimpleTextProvider(text: "Line - Destination", shortText: nil)
+            tmpl.row1Column2TextProvider = CLKSimpleTextProvider(text: "Time", shortText: nil)
+            tmpl.row2Column1TextProvider = CLKSimpleTextProvider(text: "Line - Destination", shortText: nil)
+            tmpl.row2Column2TextProvider = CLKSimpleTextProvider(text: "Time", shortText: nil)
+            
+            handler(tmpl)
+            
+        default: break
+        }
+    }
+    
+    func requestedUpdateDidBegin() {
+        // get the shared instance
+        let server = CLKComplicationServer.sharedInstance()
+        
+        // reload the timeline for all complications
+        for complication in server.activeComplications {
+            server.reloadTimelineForComplication(complication)
+        }
+    }
+    
+    func requestedUpdateBudgetExhausted() {
+        // get the shared instance
+        let server = CLKComplicationServer.sharedInstance()
+        
+        // reload the timeline for all complications
+        for complication in server.activeComplications {
+            server.reloadTimelineForComplication(complication)
+        }
+    }
+    
+    //MARK: - Convenience
+    
+    private func templateForStationDepartures(station: TFCStationBase , departure: TFCDeparture, nextDeparture: TFCDeparture?, complication: CLKComplication) -> CLKComplicationTemplate {
+        
+        let tmpl = CLKComplicationTemplateModularLargeTable() // Currently supports only ModularLarge
+        
+        tmpl.headerTextProvider = CLKSimpleTextProvider(text: station.getName(true))
+        let departureLine = departure.getLine()
+        let nextDepartureLine = nextDeparture?.getLine() ?? "-"
+
+        let nextDepartureDestination = nextDeparture?.getDestination() ?? "-"
+        
+        let units: NSCalendarUnit = [.Minute]
+        let style: CLKRelativeDateStyle = .Timer
+        
+        tmpl.row1Column1TextProvider = CLKSimpleTextProvider(text: "[\(departureLine)] - \(departure.getDestination())")
+        
+        if let departureDate = departure.getScheduledTimeAsNSDate() {
+            tmpl.row1Column2TextProvider = CLKRelativeDateTextProvider(date: departureDate, style: style, units: units)
+        } else {
+            tmpl.row1Column2TextProvider = CLKSimpleTextProvider(text: "-")
+        }
+        
+        tmpl.row2Column1TextProvider = CLKSimpleTextProvider(text: "[\(nextDepartureLine)] - \(nextDepartureDestination)")
+        
+        if let nextDepartureDate = nextDeparture?.getScheduledTimeAsNSDate() {
+            tmpl.row2Column2TextProvider = CLKRelativeDateTextProvider(date: nextDepartureDate, style: style, units: units)
+        } else {
+            tmpl.row2Column2TextProvider = CLKSimpleTextProvider(text: "-")
+        }
+    
+        return tmpl
+    }
+    
+    private func timelineEntryDateForDeparture(departure: TFCDeparture, previousDeparture: TFCDeparture?) -> NSDate {
+       
+        // If previous departure, show the next scheduled departure 1 minute after the last scheduled departure
+        // => If a bus is scheduled at 13:00, it will be displayed till 13:01
+        if let pd = previousDeparture, let date = pd.getScheduledTimeAsNSDate() {
+            return date.dateByAddingTimeInterval(Constants.DepartureDuration)
+        } else {
+            return departure.getScheduledTimeAsNSDate()!.dateByAddingTimeInterval(-6*60*60) // If no previous departure, show the departure 6 hours in advance
+        }
+    }
+}

--- a/Time for Coffee! WatchOS 2 App Extension/ComplicationController.swift
+++ b/Time for Coffee! WatchOS 2 App Extension/ComplicationController.swift
@@ -15,6 +15,7 @@ import ClockKit
 private struct Constants {
     static let DepartureDuration = NSTimeInterval(60) // 1 minute
     static let FrequencyOfTimelineUpdate = NSTimeInterval(1.5*60*60) // 1.5 hour
+    static let ComplicationColor = UIColor.orangeColor()
 }
 
 class ComplicationController: NSObject, CLKComplicationDataSource {
@@ -185,6 +186,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         let tmpl = CLKComplicationTemplateModularLargeTable() // Currently supports only ModularLarge
         
         tmpl.headerTextProvider = CLKSimpleTextProvider(text: station.getName(true))
+        tmpl.tintColor = Constants.ComplicationColor // affect only complications setup that allow custom colors
         
         let departureLine = departure.getLine()
         let nextDepartureLine = nextDeparture?.getLine() ?? "-"

--- a/Time for Coffee! WatchOS 2 App Extension/ComplicationController.swift
+++ b/Time for Coffee! WatchOS 2 App Extension/ComplicationController.swift
@@ -185,15 +185,23 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         let tmpl = CLKComplicationTemplateModularLargeTable() // Currently supports only ModularLarge
         
         tmpl.headerTextProvider = CLKSimpleTextProvider(text: station.getName(true))
+        
         let departureLine = departure.getLine()
         let nextDepartureLine = nextDeparture?.getLine() ?? "-"
-
-        let nextDepartureDestination = nextDeparture?.getDestination() ?? "-"
+        
+        var departureDestination = "-"
+        var nextDepartureDestination = "-"
+        if let tfcStation = station as? TFCStation {
+            departureDestination = departure.getDestination(tfcStation)
+            if let nextDeparture = nextDeparture {
+                nextDepartureDestination = nextDeparture.getDestination(tfcStation)
+            }
+        }
         
         let units: NSCalendarUnit = [.Minute]
         let style: CLKRelativeDateStyle = .Timer
         
-        tmpl.row1Column1TextProvider = CLKSimpleTextProvider(text: "[\(departureLine)] - \(departure.getDestination())")
+        tmpl.row1Column1TextProvider = CLKSimpleTextProvider(text: "[\(departureLine)] - \(departureDestination)")
         
         if let departureDate = departure.getScheduledTimeAsNSDate() {
             tmpl.row1Column2TextProvider = CLKRelativeDateTextProvider(date: departureDate, style: style, units: units)

--- a/Time for Coffee! WatchOS 2 App Extension/Info.plist
+++ b/Time for Coffee! WatchOS 2 App Extension/Info.plist
@@ -21,7 +21,13 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>110</string>
+	<key>CLKComplicationPrincipalClass</key>
+	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
+	<key>CLKComplicationSupportedFamilies</key>
+	<array>
+		<string>CLKComplicationFamilyModularLarge</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/timeforcoffee.xcodeproj/project.pbxproj
+++ b/timeforcoffee.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		ECEF281B1BCBC999000F4094 /* TFC.plist in Resources */ = {isa = PBXBuildFile; fileRef = ECEF28191BCBC98F000F4094 /* TFC.plist */; settings = {ASSET_TAGS = (); }; };
 		ECEF281C1BCBC9D7000F4094 /* SingleViewCoreData.sqlite-shm in Resources */ = {isa = PBXBuildFile; fileRef = EC0E4D581BCBB09F0046D70C /* SingleViewCoreData.sqlite-shm */; settings = {ASSET_TAGS = (); }; };
 		ECEF281D1BCBC9D9000F4094 /* SingleViewCoreData.sqlite-wal in Resources */ = {isa = PBXBuildFile; fileRef = EC0E4D591BCBB09F0046D70C /* SingleViewCoreData.sqlite-wal */; settings = {ASSET_TAGS = (); }; };
+		F6F721201BCA9C9C0073E0D2 /* ComplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F7211F1BCA9C9C0073E0D2 /* ComplicationController.swift */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -360,6 +361,7 @@
 		ECEDDACF1BC991800088AFB2 /* stations-importer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "stations-importer"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECEDDAD11BC991800088AFB2 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		ECEF28191BCBC98F000F4094 /* TFC.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TFC.plist; sourceTree = "<group>"; };
+		F6F7211F1BCA9C9C0073E0D2 /* ComplicationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComplicationController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -551,6 +553,7 @@
 				EC4AB2681BB6787600DA9759 /* MapViewController.swift */,
 				EC4AB2691BB6787600DA9759 /* StationRow.swift */,
 				EC4AB26A1BB6787600DA9759 /* StationsOverviewViewController.swift */,
+				F6F7211F1BCA9C9C0073E0D2 /* ComplicationController.swift */,
 				EC4AB26B1BB6787600DA9759 /* StationsRow.swift */,
 				EC4AB26C1BB6787600DA9759 /* StationViewController.swift */,
 				EC050CF71BB84D8100ECB533 /* watch-extension-bridging-Header.h */,
@@ -839,7 +842,7 @@
 					};
 					EC46C5271BB5C78A00F2A963 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = DN76797UYF;
+						DevelopmentTeam = 6EMM22S2YK;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
@@ -848,7 +851,7 @@
 					};
 					EC46C5581BB5C82800F2A963 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = DN76797UYF;
+						DevelopmentTeam = 6EMM22S2YK;
 					};
 					ECEDDACE1BC991800088AFB2 = {
 						CreatedOnToolsVersion = 7.0;
@@ -1070,6 +1073,7 @@
 				EC4AB2701BB6787600DA9759 /* StationsRow.swift in Sources */,
 				EC050CEA1BB84D4700ECB533 /* SwiftyJSON.swift in Sources */,
 				EC050CEC1BB84D4700ECB533 /* TFCDataStoreBase.swift in Sources */,
+				F6F721201BCA9C9C0073E0D2 /* ComplicationController.swift in Sources */,
 				EC4AB26E1BB6787600DA9759 /* StationRow.swift in Sources */,
 				EC050CF41BB84D5B00ECB533 /* TFCStations.swift in Sources */,
 				EC050CFA1BB84DD200ECB533 /* TFCStation.swift in Sources */,
@@ -1387,12 +1391,15 @@
 		EC46C53A1BB5C78A00F2A963 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Time for Coffee! WatchOS 2 App Extension/Time for Coffee! WatchOS 2 App Extension.entitlements";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "Time for Coffee! WatchOS 2 App Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ch.opendata.timeforcoffee.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
-				PROVISIONING_PROFILE = "d108b928-5ded-40e0-98b1-e738660c24c1";
+				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Time for Coffee! WatchOS 2 App Extension/watch-extension-bridging-Header.h";
@@ -1404,12 +1411,15 @@
 		EC46C53B1BB5C78A00F2A963 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Time for Coffee! WatchOS 2 App Extension/Time for Coffee! WatchOS 2 App Extension.entitlements";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "Time for Coffee! WatchOS 2 App Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ch.opendata.timeforcoffee.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
-				PROVISIONING_PROFILE = "d108b928-5ded-40e0-98b1-e738660c24c1";
+				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Time for Coffee! WatchOS 2 App Extension/watch-extension-bridging-Header.h";

--- a/timeforcoffee.xcodeproj/project.pbxproj
+++ b/timeforcoffee.xcodeproj/project.pbxproj
@@ -842,7 +842,7 @@
 					};
 					EC46C5271BB5C78A00F2A963 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 6EMM22S2YK;
+						DevelopmentTeam = DN76797UYF;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
@@ -851,7 +851,7 @@
 					};
 					EC46C5581BB5C82800F2A963 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 6EMM22S2YK;
+						DevelopmentTeam = DN76797UYF;
 					};
 					ECEDDACE1BC991800088AFB2 = {
 						CreatedOnToolsVersion = 7.0;
@@ -1399,7 +1399,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ch.opendata.timeforcoffee.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "d108b928-5ded-40e0-98b1-e738660c24c1";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Time for Coffee! WatchOS 2 App Extension/watch-extension-bridging-Header.h";
@@ -1419,7 +1419,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ch.opendata.timeforcoffee.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "d108b928-5ded-40e0-98b1-e738660c24c1";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Time for Coffee! WatchOS 2 App Extension/watch-extension-bridging-Header.h";

--- a/timeforcoffeeKit/TFCDeparture.swift
+++ b/timeforcoffeeKit/TFCDeparture.swift
@@ -217,6 +217,13 @@ public final class TFCDeparture: NSObject, NSCoding {
         }
         return nil
     }
+    
+    public func getScheduledTimeAsNSDate() -> NSDate? {
+        if let scheduled = self.scheduled {
+            return scheduled
+        }
+        return nil
+    }
 
     public func getDepartureTime(additionalInfo: Bool) -> (NSMutableAttributedString?, String?) {
         var realtimeStr: String = ""


### PR DESCRIPTION
Hey!

Have a look at my implementation of complication ModularLarge.

It still needs some testing, however I couldn't test it on my iWatch as I don't have the right provisioning profile, only in the simulator, which is not so great to test.

It also needs some tuning/ improvement, specially for deciding when the complication data should be extended/reloaded. 

Currently the first station returned by the method "getStations" is defined as the one appearing on the clockFace and the data are reloaded every 1.5 hour. To this regard, what is the exact criteria for the ordering of the returned stations from method "getStations" ? It seemed to me it was the last favorited station first, but I noticed it takes into account the distance as well. 

| Complication ModularLarge | Time Travel |
| --- | --- |
| ![simulator screen shot 13 oct 2015 11 27 57](https://cloud.githubusercontent.com/assets/11804885/10451079/4f956fd2-719e-11e5-97ef-698839f64840.png) | ![simulator screen shot 13 oct 2015 11 33 50](https://cloud.githubusercontent.com/assets/11804885/10451092/5d73cac2-719e-11e5-89f3-81544f95ca62.png) |

Display the next two departures from the closest/favorited station on the clockFace in ModularLarge family

Once the complication is set by the user, it allows him to see immediately the remaining time till the next departures
The user can also use time travel feature to look at the future departures.

Limitations
- The station displayed on the clockFace corresponds to the first station returned from the "getStations" method
- The method "getStations" is called multiple times
- So far, the timeline entries are not reloaded when the order of the returned stations change
- The timeline entries are reloaded every 1.5 hour arbitrarly
- The text format of the bus/train line and remaining time till departure don't give a clear indication of what they display
- The destination is truncated
